### PR TITLE
Hide "Try Premium for free" & "For Business"

### DIFF
--- a/linkedin.txt
+++ b/linkedin.txt
@@ -11,3 +11,17 @@ www.linkedin.com##.premium-upsell-link--extra-long
 ! Hide LinkedIn messages overlay
 www.linkedin.com##.msg-overlay-container-reflow.msg-overlay-container
 www.linkedin.com##.mb2.artdeco-card.community-panel
+
+! Hide LinkedIn Pay for premium under the profile in Feed page
+www.linkedin.com##.text-align-left.link-without-hover-state.t-bold.t-black.t-12.feed-identity-module__anchored-widget--premium-upsell.feed-identity-module__anchored-widget.link-without-visited-state.app-aware-link
+
+! Hide LinkedIn  "Try Premium for free" top bar
+www.linkedin.com##.premium-upsell-link--truncate.global-nav__spotlight-upsell.global-nav__primary-link--premium.global-nav__primary-link.link-without-visited-state
+
+! Hide LinkedIn "Try Premium for free" in My Network ! NOTE: loading this page is slower if enabled
+www.linkedin.com##.relative.flex-column.display-flex.align-items-left.mb4.artdeco-card.p4.mn-sales-navigator-upsell
+www.linkedin.com##.artdeco-card.full-width.mn-abi-form__container
+
+! Hide "For Business" Top Bar
+www.linkedin.com##.flex-column.display-flex.align-items-left.mt5.p4.artdeco-card
+www.linkedin.com##.global-nav__app-launcher-trigger.pl3.global-nav__primary-item--divider.global-nav__primary-link

--- a/linkedin.txt
+++ b/linkedin.txt
@@ -12,16 +12,15 @@ www.linkedin.com##.premium-upsell-link--extra-long
 www.linkedin.com##.msg-overlay-container-reflow.msg-overlay-container
 www.linkedin.com##.mb2.artdeco-card.community-panel
 
-! Hide LinkedIn Pay for premium under the profile in Feed page
-www.linkedin.com##.text-align-left.link-without-hover-state.t-bold.t-black.t-12.feed-identity-module__anchored-widget--premium-upsell.feed-identity-module__anchored-widget.link-without-visited-state.app-aware-link
-
-! Hide LinkedIn  "Try Premium for free" top bar
-www.linkedin.com##.premium-upsell-link--truncate.global-nav__spotlight-upsell.global-nav__primary-link--premium.global-nav__primary-link.link-without-visited-state
-
-! Hide LinkedIn "Try Premium for free" in My Network ! NOTE: loading this page is slower if enabled
+! Hide LinkedIn "Try Premium for free" in My Network
 www.linkedin.com##.relative.flex-column.display-flex.align-items-left.mb4.artdeco-card.p4.mn-sales-navigator-upsell
 www.linkedin.com##.artdeco-card.full-width.mn-abi-form__container
 
 ! Hide "For Business" Top Bar
 www.linkedin.com##.flex-column.display-flex.align-items-left.mt5.p4.artdeco-card
 www.linkedin.com##.global-nav__app-launcher-trigger.pl3.global-nav__primary-item--divider.global-nav__primary-link
+
+!linkenIn remove "Try Premium for free" both in specific job and Jobs search
+www.linkedin.com##.premium-accent-bar.ember-view.artdeco-card
+www.linkedin.com##.ph5.pv4.job-details-how-you-match-card__upsell
+www.linkedin.com##.flex-column.display-flex.align-items-left.p4.justify-center.artdeco-card

--- a/linkedin.txt
+++ b/linkedin.txt
@@ -16,11 +16,11 @@ www.linkedin.com##.mb2.artdeco-card.community-panel
 www.linkedin.com##.relative.flex-column.display-flex.align-items-left.mb4.artdeco-card.p4.mn-sales-navigator-upsell
 www.linkedin.com##.artdeco-card.full-width.mn-abi-form__container
 
-! Hide "For Business" Top Bar
+! Hide LinkedIn "For Business" Top Bar
 www.linkedin.com##.flex-column.display-flex.align-items-left.mt5.p4.artdeco-card
 www.linkedin.com##.global-nav__app-launcher-trigger.pl3.global-nav__primary-item--divider.global-nav__primary-link
 
-!linkenIn remove "Try Premium for free" both in specific job and Jobs search
+! Hide LinkedIn "Try Premium for free" both in specific job and Jobs search
 www.linkedin.com##.premium-accent-bar.ember-view.artdeco-card
 www.linkedin.com##.ph5.pv4.job-details-how-you-match-card__upsell
 www.linkedin.com##.flex-column.display-flex.align-items-left.p4.justify-center.artdeco-card


### PR DESCRIPTION
Hide "Try Premium for free" is multiple places such: Top bar, Side bar (in home feed), My network and "Messaging"

Hide "For Business" from top bar

| Before | After |
:------:  | :------:
|<img src="https://github.com/mig4ng/ublock-origin-filters/assets/52387015/04808228-3d0d-4fc3-a911-0cd83fef0e87" alt="HomeBefore" width="400"/> | <img src="https://github.com/mig4ng/ublock-origin-filters/assets/52387015/4e96faff-9109-4c51-bc10-f80ae9117853" alt="HomeAfter" width="400"/>  |
|<img src="https://github.com/mig4ng/ublock-origin-filters/assets/52387015/fe985950-9d49-4e03-8dd7-bd86361269d6" alt="FeedBefore" width="400"/> | <img src="https://github.com/mig4ng/ublock-origin-filters/assets/52387015/c9cf650a-fa41-40a6-91f9-072475c78992" alt="FeedAfter" width="400"/>|


hope that helps (:
