### PR TITLE
Hide Twitter "Verified" left sidebar menu item

### DIFF
--- a/twitter.txt
+++ b/twitter.txt
@@ -27,3 +27,8 @@ twitter.com##*[aria-label="New Tweets are available. Push the period key to go t
 !twitter.com##*[data-testid="cellInnerDiv"]:has-text('Sourced from across Twitter'):xpath(following-sibling::div)
 ! Send me an email if you fixed this on. My username at gmail.com. My username is the same as the one in GitHub.
 
+! Hide Twitter 'Verified' left side menu item
+twitter.com##*[role="link"][aria-label="Verified"]
+
+! Hide Twitter 'Communities' left side menu item
+!twitter.com##*[role="link"][aria-label="Communities (New items)"]

--- a/twitter.txt
+++ b/twitter.txt
@@ -28,7 +28,7 @@ twitter.com##*[aria-label="New Tweets are available. Push the period key to go t
 ! Send me an email if you fixed this on. My username at gmail.com. My username is the same as the one in GitHub.
 
 ! Hide Twitter 'Verified' left side menu item
-twitter.com##*[role="link"][aria-label="Verified"]
+twitter.com##nav [role="link"][aria-label="Verified"]
 
 ! Hide Twitter 'Communities' left side menu item
-!twitter.com##*[role="link"][aria-label="Communities (New items)"]
+! twitter.com##nav [role="link"][aria-label="Communities (New items)"]


### PR DESCRIPTION
This filter is adding filters for the Twitter left navigation sidebar. Since the verified/premium items on the right sidebar are already hidden I added a similar filter to include the left sidebar.

The second entry (disabled by default) removes the "Communities" item.

![Screenshot 2023-09-20 at 17 14 51](https://github.com/mig4ng/ublock-origin-filters/assets/11266773/0a6a8b2e-7c92-441c-b5a3-330745552681)
